### PR TITLE
Add IP Family Policy and IP Families to CRD for Services

### DIFF
--- a/config/crd/bases/postgres-operator.crunchydata.com_postgresclusters.yaml
+++ b/config/crd/bases/postgres-operator.crunchydata.com_postgresclusters.yaml
@@ -14663,6 +14663,14 @@ spec:
                             - Local
                             maxLength: 10
                             type: string
+                          ipFamilies:
+                            items:
+                              enum:
+                              - IPv4
+                              - IPv6
+                              - foo
+                              type: string
+                            type: array
                           ipFamilyPolicy:
                             description: 'More info: https://kubernetes.io/docs/reference/kubernetes-api/service-resources/service-v1/'
                             enum:
@@ -15012,6 +15020,14 @@ spec:
                     - Local
                     maxLength: 10
                     type: string
+                  ipFamilies:
+                    items:
+                      enum:
+                      - IPv4
+                      - IPv6
+                      - foo
+                      type: string
+                    type: array
                   ipFamilyPolicy:
                     description: 'More info: https://kubernetes.io/docs/reference/kubernetes-api/service-resources/service-v1/'
                     enum:
@@ -15067,6 +15083,14 @@ spec:
                     - Local
                     maxLength: 10
                     type: string
+                  ipFamilies:
+                    items:
+                      enum:
+                      - IPv4
+                      - IPv6
+                      - foo
+                      type: string
+                    type: array
                   ipFamilyPolicy:
                     description: 'More info: https://kubernetes.io/docs/reference/kubernetes-api/service-resources/service-v1/'
                     enum:
@@ -16770,6 +16794,14 @@ spec:
                             - Local
                             maxLength: 10
                             type: string
+                          ipFamilies:
+                            items:
+                              enum:
+                              - IPv4
+                              - IPv6
+                              - foo
+                              type: string
+                            type: array
                           ipFamilyPolicy:
                             description: 'More info: https://kubernetes.io/docs/reference/kubernetes-api/service-resources/service-v1/'
                             enum:

--- a/config/crd/bases/postgres-operator.crunchydata.com_postgresclusters.yaml
+++ b/config/crd/bases/postgres-operator.crunchydata.com_postgresclusters.yaml
@@ -14663,6 +14663,13 @@ spec:
                             - Local
                             maxLength: 10
                             type: string
+                          ipFamilyPolicy:
+                            description: 'More info: https://kubernetes.io/docs/reference/kubernetes-api/service-resources/service-v1/'
+                            enum:
+                            - SingleStack
+                            - PreferDualStack
+                            - RequireDualStack
+                            type: string
                           metadata:
                             description: Metadata contains metadata for custom resources
                             properties:
@@ -15005,6 +15012,13 @@ spec:
                     - Local
                     maxLength: 10
                     type: string
+                  ipFamilyPolicy:
+                    description: 'More info: https://kubernetes.io/docs/reference/kubernetes-api/service-resources/service-v1/'
+                    enum:
+                    - SingleStack
+                    - PreferDualStack
+                    - RequireDualStack
+                    type: string
                   metadata:
                     description: Metadata contains metadata for custom resources
                     properties:
@@ -15052,6 +15066,13 @@ spec:
                     - Cluster
                     - Local
                     maxLength: 10
+                    type: string
+                  ipFamilyPolicy:
+                    description: 'More info: https://kubernetes.io/docs/reference/kubernetes-api/service-resources/service-v1/'
+                    enum:
+                    - SingleStack
+                    - PreferDualStack
+                    - RequireDualStack
                     type: string
                   metadata:
                     description: Metadata contains metadata for custom resources
@@ -16748,6 +16769,13 @@ spec:
                             - Cluster
                             - Local
                             maxLength: 10
+                            type: string
+                          ipFamilyPolicy:
+                            description: 'More info: https://kubernetes.io/docs/reference/kubernetes-api/service-resources/service-v1/'
+                            enum:
+                            - SingleStack
+                            - PreferDualStack
+                            - RequireDualStack
                             type: string
                           metadata:
                             description: Metadata contains metadata for custom resources

--- a/internal/controller/postgrescluster/cluster.go
+++ b/internal/controller/postgrescluster/cluster.go
@@ -268,11 +268,17 @@ func (r *Reconciler) generateClusterReplicaService(
 		service.Spec.ExternalTrafficPolicy = initialize.FromPointer(spec.ExternalTrafficPolicy)
 		service.Spec.InternalTrafficPolicy = spec.InternalTrafficPolicy
 
-		// Default to SingleStack if IP Family Policy is not defined
-		if spec.IPFamilyPolicy == "" {
-			spec.IPFamilyPolicy = "SingleStack"
+		// Set IPFamilyPolicy and IPFamilies
+		if spec.IPFamilyPolicy != "" {
+			policy := corev1.IPFamilyPolicyType(spec.IPFamilyPolicy)
+			service.Spec.IPFamilyPolicy = &policy
 		}
-		service.Spec.IPFamilyPolicy = (*corev1.IPFamilyPolicy)(&spec.IPFamilyPolicy)
+		if len(spec.IPFamilies) > 0 {
+			service.Spec.IPFamilies = []corev1.IPFamily{}
+			for _, family := range spec.IPFamilies {
+				service.Spec.IPFamilies = append(service.Spec.IPFamilies, corev1.IPFamily(family))
+			}
+		}
 
 	}
 	service.Spec.Ports = []corev1.ServicePort{servicePort}

--- a/internal/controller/postgrescluster/cluster.go
+++ b/internal/controller/postgrescluster/cluster.go
@@ -267,6 +267,13 @@ func (r *Reconciler) generateClusterReplicaService(
 		}
 		service.Spec.ExternalTrafficPolicy = initialize.FromPointer(spec.ExternalTrafficPolicy)
 		service.Spec.InternalTrafficPolicy = spec.InternalTrafficPolicy
+
+		// Default to SingleStack if IP Family Policy is not defined
+		if spec.IPFamilyPolicy == "" {
+			spec.IPFamilyPolicy = "SingleStack"
+		}
+		service.Spec.IPFamilyPolicy = (*corev1.IPFamilyPolicy)(&spec.IPFamilyPolicy)
+
 	}
 	service.Spec.Ports = []corev1.ServicePort{servicePort}
 

--- a/internal/controller/postgrescluster/patroni.go
+++ b/internal/controller/postgrescluster/patroni.go
@@ -271,6 +271,12 @@ func (r *Reconciler) generatePatroniLeaderLeaseService(
 		}
 		service.Spec.ExternalTrafficPolicy = initialize.FromPointer(spec.ExternalTrafficPolicy)
 		service.Spec.InternalTrafficPolicy = spec.InternalTrafficPolicy
+
+		// Default to SingleStack if IP Family Policy is not defined
+		if spec.IPFamilyPolicy == "" {
+			spec.IPFamilyPolicy = "SingleStack"
+		}
+		service.Spec.IPFamilyPolicy = (*corev1.IPFamilyPolicy)(&spec.IPFamilyPolicy)
 	}
 	service.Spec.Ports = []corev1.ServicePort{servicePort}
 

--- a/internal/controller/postgrescluster/patroni.go
+++ b/internal/controller/postgrescluster/patroni.go
@@ -272,11 +272,17 @@ func (r *Reconciler) generatePatroniLeaderLeaseService(
 		service.Spec.ExternalTrafficPolicy = initialize.FromPointer(spec.ExternalTrafficPolicy)
 		service.Spec.InternalTrafficPolicy = spec.InternalTrafficPolicy
 
-		// Default to SingleStack if IP Family Policy is not defined
-		if spec.IPFamilyPolicy == "" {
-			spec.IPFamilyPolicy = "SingleStack"
+		// Set IPFamilyPolicy and IPFamilies
+		if spec.IPFamilyPolicy != "" {
+			policy := corev1.IPFamilyPolicyType(spec.IPFamilyPolicy)
+			service.Spec.IPFamilyPolicy = &policy
 		}
-		service.Spec.IPFamilyPolicy = (*corev1.IPFamilyPolicy)(&spec.IPFamilyPolicy)
+		if len(spec.IPFamilies) > 0 {
+			service.Spec.IPFamilies = []corev1.IPFamily{}
+			for _, family := range spec.IPFamilies {
+				service.Spec.IPFamilies = append(service.Spec.IPFamilies, corev1.IPFamily(family))
+			}
+		}
 	}
 	service.Spec.Ports = []corev1.ServicePort{servicePort}
 

--- a/internal/controller/postgrescluster/pgadmin.go
+++ b/internal/controller/postgrescluster/pgadmin.go
@@ -184,11 +184,17 @@ func (r *Reconciler) generatePGAdminService(
 		service.Spec.ExternalTrafficPolicy = initialize.FromPointer(spec.ExternalTrafficPolicy)
 		service.Spec.InternalTrafficPolicy = spec.InternalTrafficPolicy
 
-		// Default to SingleStack if IP Family Policy is not defined
-		if spec.IPFamilyPolicy == "" {
-			spec.IPFamilyPolicy = "SingleStack"
+		// Set IPFamilyPolicy and IPFamilies
+		if spec.IPFamilyPolicy != "" {
+			policy := corev1.IPFamilyPolicyType(spec.IPFamilyPolicy)
+			service.Spec.IPFamilyPolicy = &policy
 		}
-		service.Spec.IPFamilyPolicy = (*corev1.IPFamilyPolicy)(&spec.IPFamilyPolicy)
+		if len(spec.IPFamilies) > 0 {
+			service.Spec.IPFamilies = []corev1.IPFamily{}
+			for _, family := range spec.IPFamilies {
+				service.Spec.IPFamilies = append(service.Spec.IPFamilies, corev1.IPFamily(family))
+			}
+		}
 	}
 	service.Spec.Ports = []corev1.ServicePort{servicePort}
 

--- a/internal/controller/postgrescluster/pgadmin.go
+++ b/internal/controller/postgrescluster/pgadmin.go
@@ -183,6 +183,12 @@ func (r *Reconciler) generatePGAdminService(
 		}
 		service.Spec.ExternalTrafficPolicy = initialize.FromPointer(spec.ExternalTrafficPolicy)
 		service.Spec.InternalTrafficPolicy = spec.InternalTrafficPolicy
+
+		// Default to SingleStack if IP Family Policy is not defined
+		if spec.IPFamilyPolicy == "" {
+			spec.IPFamilyPolicy = "SingleStack"
+		}
+		service.Spec.IPFamilyPolicy = (*corev1.IPFamilyPolicy)(&spec.IPFamilyPolicy)
 	}
 	service.Spec.Ports = []corev1.ServicePort{servicePort}
 

--- a/internal/controller/postgrescluster/pgbouncer.go
+++ b/internal/controller/postgrescluster/pgbouncer.go
@@ -307,11 +307,17 @@ func (r *Reconciler) generatePGBouncerService(
 		service.Spec.ExternalTrafficPolicy = initialize.FromPointer(spec.ExternalTrafficPolicy)
 		service.Spec.InternalTrafficPolicy = spec.InternalTrafficPolicy
 
-		// Default to SingleStack if IP Family Policy is not defined
-		if spec.IPFamilyPolicy == "" {
-			spec.IPFamilyPolicy = "SingleStack"
+		// Set IPFamilyPolicy and IPFamilies
+		if spec.IPFamilyPolicy != "" {
+			policy := corev1.IPFamilyPolicyType(spec.IPFamilyPolicy)
+			service.Spec.IPFamilyPolicy = &policy
 		}
-		service.Spec.IPFamilyPolicy = (*corev1.IPFamilyPolicy)(&spec.IPFamilyPolicy)
+		if len(spec.IPFamilies) > 0 {
+			service.Spec.IPFamilies = []corev1.IPFamily{}
+			for _, family := range spec.IPFamilies {
+				service.Spec.IPFamilies = append(service.Spec.IPFamilies, corev1.IPFamily(family))
+			}
+		}
 	}
 	service.Spec.Ports = []corev1.ServicePort{servicePort}
 

--- a/internal/controller/postgrescluster/pgbouncer.go
+++ b/internal/controller/postgrescluster/pgbouncer.go
@@ -306,6 +306,12 @@ func (r *Reconciler) generatePGBouncerService(
 		}
 		service.Spec.ExternalTrafficPolicy = initialize.FromPointer(spec.ExternalTrafficPolicy)
 		service.Spec.InternalTrafficPolicy = spec.InternalTrafficPolicy
+
+		// Default to SingleStack if IP Family Policy is not defined
+		if spec.IPFamilyPolicy == "" {
+			spec.IPFamilyPolicy = "SingleStack"
+		}
+		service.Spec.IPFamilyPolicy = (*corev1.IPFamilyPolicy)(&spec.IPFamilyPolicy)
 	}
 	service.Spec.Ports = []corev1.ServicePort{servicePort}
 

--- a/pkg/apis/postgres-operator.crunchydata.com/v1beta1/shared_types.go
+++ b/pkg/apis/postgres-operator.crunchydata.com/v1beta1/shared_types.go
@@ -20,7 +20,11 @@ type SchemalessObject map[string]any
 // DeepCopy creates a new SchemalessObject by copying the receiver.
 func (in SchemalessObject) DeepCopy() SchemalessObject {
 	return runtime.DeepCopyJSON(in)
+
 }
+
+// +kubebuilder:validation:Enum=IPv4;IPv6;foo
+type IPFamily string
 
 type ServiceSpec struct {
 	// +optional
@@ -49,6 +53,9 @@ type ServiceSpec struct {
 	// +optional
 	// +kubebuilder:validation:Enum=SingleStack;PreferDualStack;RequireDualStack
 	IPFamilyPolicy string `json:"ipFamilyPolicy,omitempty"`
+
+	// +optional
+	IPFamilies []IPFamily `json:"ipFamilies,omitempty"`
 
 	// More info: https://kubernetes.io/docs/concepts/services-networking/service/#traffic-policies
 	// ---

--- a/pkg/apis/postgres-operator.crunchydata.com/v1beta1/shared_types.go
+++ b/pkg/apis/postgres-operator.crunchydata.com/v1beta1/shared_types.go
@@ -44,6 +44,12 @@ type ServiceSpec struct {
 	// +kubebuilder:validation:Enum={ClusterIP,NodePort,LoadBalancer}
 	Type string `json:"type"`
 
+	// More info: https://kubernetes.io/docs/reference/kubernetes-api/service-resources/service-v1/
+	// ---
+	// +optional
+	// +kubebuilder:validation:Enum=SingleStack;PreferDualStack;RequireDualStack
+	IPFamilyPolicy string `json:"ipFamilyPolicy,omitempty"`
+
 	// More info: https://kubernetes.io/docs/concepts/services-networking/service/#traffic-policies
 	// ---
 	// Kubernetes assumes the evaluation cost of an enum value is very large.

--- a/pkg/apis/postgres-operator.crunchydata.com/v1beta1/zz_generated.deepcopy.go
+++ b/pkg/apis/postgres-operator.crunchydata.com/v1beta1/zz_generated.deepcopy.go
@@ -2213,6 +2213,11 @@ func (in *ServiceSpec) DeepCopyInto(out *ServiceSpec) {
 		*out = new(int32)
 		**out = **in
 	}
+	if in.IPFamilies != nil {
+		in, out := &in.IPFamilies, &out.IPFamilies
+		*out = make([]IPFamily, len(*in))
+		copy(*out, *in)
+	}
 	if in.InternalTrafficPolicy != nil {
 		in, out := &in.InternalTrafficPolicy, &out.InternalTrafficPolicy
 		*out = new(corev1.ServiceInternalTrafficPolicy)


### PR DESCRIPTION
**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [ ] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [ ] Have you updated or added documentation for the change, as applicable?
 - [ ] Have you tested your changes on all related environments with successful results, as applicable?
   - [ ] Have you added automated tests?



**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [x] New feature
 - [ ] Bug fix
 - [ ] Documentation
 - [ ] Testing enhancement
 - [ ] Other


**What is the current behavior (link to any open issues here)?**

Add ipFamilyPolicy and IPFamilies as a managed field for all services

- Patroni Primary Lease Service
- Replica Service
- pgAdmin Service
- pgBouncer Service

**What is the new behavior (if this is a feature change)?**
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- This allows users to specify the ipFamilyPolicy for all Services managed by the Operator. Acceptable values are SingleStack, PreferDualStack, and RequireDualStack


**Other Information**:
